### PR TITLE
Added the AvatarStateOnFinalBlow and Randomly Select a Player's Element When They Join

### DIFF
--- a/src/com/projectkorra/rpg/ConfigManager.java
+++ b/src/com/projectkorra/rpg/ConfigManager.java
@@ -33,6 +33,14 @@ public class ConfigManager {
 		config.addDefault("WorldEvents.SozinsComet.Time", "Day");
 		
 		config.addDefault("Abilities.AvatarStateOnFinalBlow", true);
+		
+		config.addDefault("ElementAssign.Enabled", true);
+		config.addDefault("ElementAssign.Default", "Earth");
+		config.addDefault("ElementAssign.Percentages.Earth", 0.205);
+		config.addDefault("ElementAssign.Percentages.Water", 0.205);
+		config.addDefault("ElementAssign.Percentages.Air", 0.205);
+		config.addDefault("ElementAssign.Percentages.Fire", 0.205);
+		config.addDefault("ElementAssign.Percentages.Earth", 0.18);
 	}
 
 }

--- a/src/com/projectkorra/rpg/RPGListener.java
+++ b/src/com/projectkorra/rpg/RPGListener.java
@@ -4,6 +4,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDamageEvent;
+import org.bukkit.event.player.PlayerJoinEvent;
 
 import com.projectkorra.ProjectKorra.BendingPlayer;
 import com.projectkorra.ProjectKorra.Methods;
@@ -30,6 +31,20 @@ public class RPGListener implements Listener{
 						new AvatarState(player);
 					}
 				}
+			}
+		}
+	}
+	
+	@EventHandler
+	public void randomElementAssign(PlayerJoinEvent event) {
+		
+		if(!ProjectKorraRPG.plugin.getConfig().getBoolean("ElementAssign.Enabled")) return;
+		
+		if(Methods.getBendingPlayer(event.getPlayer().getName()) != null) {
+			BendingPlayer bp = Methods.getBendingPlayer(event.getPlayer().getName());
+			
+			if((bp.getElements().isEmpty()) && (!bp.isPermaRemoved())) {
+				RPGMethods.randomAssign(bp);
 			}
 		}
 	}

--- a/src/com/projectkorra/rpg/RPGMethods.java
+++ b/src/com/projectkorra/rpg/RPGMethods.java
@@ -1,7 +1,11 @@
 package com.projectkorra.rpg;
 
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
 import org.bukkit.World;
 
+import com.projectkorra.ProjectKorra.BendingPlayer;
+import com.projectkorra.ProjectKorra.Element;
 import com.projectkorra.ProjectKorra.Methods;
 
 public class RPGMethods {
@@ -54,4 +58,66 @@ public class RPGMethods {
 		return ProjectKorraRPG.plugin.getConfig().getDouble("WorldEvents." + we.toString() + ".Factor");
 	}
 	
+	public static void randomAssign(BendingPlayer player) {
+		double earthchance = ProjectKorraRPG.plugin.getConfig().getDouble("ElementAssign.Percentages.Earth");
+		double firechance = ProjectKorraRPG.plugin.getConfig().getDouble("ElementAssign.Percentages.Fire");
+		double airchance = ProjectKorraRPG.plugin.getConfig().getDouble("ElementAssign.Percentages.Air");
+		double waterchance = ProjectKorraRPG.plugin.getConfig().getDouble("ElementAssign.Percentages.Water");
+		double chichance = ProjectKorraRPG.plugin.getConfig().getDouble("ElementAssign.Percentages.Chi");
+		
+		if(ProjectKorraRPG.plugin.getConfig().getBoolean("ElementAssign.Enabled")) {
+			if (Math.random() < earthchance) {
+				assignElement(player, Element.Earth, false);
+				return;
+			}
+			
+			if (Math.random() < waterchance) {
+				assignElement(player, Element.Water, false);
+				return;
+			}
+			
+			if (Math.random() < airchance) {
+				assignElement(player, Element.Air, false);
+				return;
+			}
+			
+			if (Math.random() < firechance) {
+				assignElement(player, Element.Fire, false);
+				return;
+			}
+			
+			if (Math.random() < chichance) {
+				assignElement(player, Element.Chi, true);
+				return;
+			}
+			
+			String defaultElement = ProjectKorraRPG.plugin.getConfig().getString("ElementAssign.Default");
+			Element e = Element.Earth;
+			
+			if(defaultElement.equalsIgnoreCase("Chi")) {
+				assignElement(player, Element.Chi, true);
+				return;
+			}
+			
+			if(defaultElement.equalsIgnoreCase("Water")) e = Element.Water;
+			if(defaultElement.equalsIgnoreCase("Earth")) e = Element.Earth;
+			if(defaultElement.equalsIgnoreCase("Fire")) e = Element.Fire;
+			if(defaultElement.equalsIgnoreCase("Air")) e = Element.Air;
+			
+			assignElement(player, e, false);
+			return;
+		}
+	}
+	
+	private static void assignElement(BendingPlayer player, Element e, Boolean chiblocker) {
+		player.setElement(e);
+		if(!chiblocker) {
+			if(e.toString().equalsIgnoreCase("Earth")) Bukkit.getPlayer(player.getUUID()).sendMessage(ChatColor.RED + "You have been born as an " + Methods.getEarthColor() + e.toString() + "bender!");
+			if(e.toString().equalsIgnoreCase("Fire")) Bukkit.getPlayer(player.getUUID()).sendMessage(ChatColor.RED + "You have been born as a " + Methods.getFireColor() + e.toString() + "bender!");
+			if(e.toString().equalsIgnoreCase("Water")) Bukkit.getPlayer(player.getUUID()).sendMessage(ChatColor.RED + "You have been born as a " + Methods.getWaterColor() + e.toString() + "bender!");
+			if(e.toString().equalsIgnoreCase("Air")) Bukkit.getPlayer(player.getUUID()).sendMessage(ChatColor.RED + "You have been born as an " + Methods.getAirColor() + e.toString() + "bender!");
+		}else{
+			Bukkit.getPlayer(player.getUUID()).sendMessage(ChatColor.RED + "You have been raised as a " + Methods.getChiColor() + e.toString() + "blocker!");
+		}
+	}
 }

--- a/src/config.yml
+++ b/src/config.yml
@@ -19,3 +19,12 @@ WorldEvents:
     Time: Day
 Abilities:
   AvatarStateOnFinalBlow: true
+ElementAssign:
+  Enabled: true
+  Default: Earth
+  Percentages:
+    Air: 0.205
+    Fire: 0.205
+    Water: 0.205
+    Earth: 0.205
+    Chi: 0.18


### PR DESCRIPTION
When a player with access to the Avatar State is going to receive a
killing blow, they will not die and will access the Avatar State. This
is able to be enabled and disabled in the config.

---

A player is randomly assigned to be either a chiblocker or a bender.
This can be disabled, the percentages are customizable, and the default
element if they don't receive the others is also customizable.
