### PR TITLE
Major fixes and changes to RPG

### DIFF
--- a/src/com/projectkorra/rpg/ProjectKorraRPG.java
+++ b/src/com/projectkorra/rpg/ProjectKorraRPG.java
@@ -2,14 +2,20 @@ package com.projectkorra.rpg;
 
 import com.projectkorra.rpg.commands.AvatarCommand;
 import com.projectkorra.rpg.commands.EventCommand;
+import com.projectkorra.rpg.commands.HelpCommand;
+import com.projectkorra.rpg.commands.RPGCommandBase;
 import com.projectkorra.rpg.configuration.ConfigManager;
 import com.projectkorra.rpg.event.EventManager;
+import com.projectkorra.rpg.storage.DBConnection;
 import com.projectkorra.rpg.util.MetricsLite;
 
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.java.JavaPlugin;
 
 import java.io.IOException;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Logger;
 
 public class ProjectKorraRPG extends JavaPlugin {
@@ -24,8 +30,12 @@ public class ProjectKorraRPG extends JavaPlugin {
 		
 		new ConfigManager();
 		new RPGMethods();
+		new RPGCommandBase();
 		new AvatarCommand();
 		new EventCommand();
+		new HelpCommand();
+		
+		importDatabase();
 		
 		Bukkit.getServer().getPluginManager().registerEvents(new RPGListener(), this);
 		Bukkit.getServer().getScheduler().scheduleSyncRepeatingTask(plugin, new EventManager(), 0L, 1L);
@@ -37,11 +47,51 @@ public class ProjectKorraRPG extends JavaPlugin {
 	        e.printStackTrace();
 	        log.info("Failed to load metric stats");
 	    }
-		
 	}
 	
 	@Override
 	public void onDisable() {
+		// Might do something later
+	}
+	
+	public void importDatabase() {
+		DBConnection.open();
+		ProjectKorraRPG.log.info("Attempting to connect to the database.");
 		
+		if (!DBConnection.isOpen()) {
+			ProjectKorraRPG.log.info("Failed to connect to the database.");
+			return;
+		}
+		if (!DBConnection.sql.tableExists("pk_avatars")) {
+			ProjectKorraRPG.log.info("Table no longer exists, import aborted.");
+			DBConnection.close();
+			return;
+		}
+		ConcurrentHashMap<String, String> avatars = new ConcurrentHashMap<>();
+		ResultSet rs = DBConnection.sql.readQuery("SELECT * FROM pk_avatars WHERE uuid IS NOT NULL");
+		
+		try {
+			while (rs.next()) {
+				String uuid = rs.getString(2);
+				String elements = rs.getString(4);
+				avatars.putIfAbsent(uuid, elements);
+			}
+		}
+		catch (SQLException e) {
+			e.printStackTrace();
+			ProjectKorraRPG.log.info("Exception occured. Database closed.");
+			DBConnection.close();
+			return;
+		}
+		
+		for (String uuid : avatars.keySet()) {
+			String elements = avatars.get(uuid);
+			if (ConfigManager.avatarConfig.get().contains("Avatar.Past." + uuid))
+				ConfigManager.avatarConfig.get().set("Avatar.Past." + uuid, elements);
+		}
+		
+		ConfigManager.avatarConfig.save();
+		ProjectKorraRPG.log.info("Import successful, Database closed.");
+		DBConnection.close();
 	}
 }

--- a/src/com/projectkorra/rpg/ProjectKorraRPG.java
+++ b/src/com/projectkorra/rpg/ProjectKorraRPG.java
@@ -12,6 +12,7 @@ import com.projectkorra.rpg.util.MetricsLite;
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.java.JavaPlugin;
 
+import java.io.File;
 import java.io.IOException;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -35,7 +36,12 @@ public class ProjectKorraRPG extends JavaPlugin {
 		new EventCommand();
 		new HelpCommand();
 		
-		importDatabase();
+		if (this.getDataFolder() != null) {
+			if (new File(this.getDataFolder(), "projectkorra.db").exists()) {
+				importDatabase();
+			}
+		}
+		
 		
 		Bukkit.getServer().getPluginManager().registerEvents(new RPGListener(), this);
 		Bukkit.getServer().getScheduler().scheduleSyncRepeatingTask(plugin, new EventManager(), 0L, 1L);

--- a/src/com/projectkorra/rpg/ProjectKorraRPG.java
+++ b/src/com/projectkorra/rpg/ProjectKorraRPG.java
@@ -12,11 +12,7 @@ import com.projectkorra.rpg.util.MetricsLite;
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.java.JavaPlugin;
 
-import java.io.File;
 import java.io.IOException;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Logger;
 
 public class ProjectKorraRPG extends JavaPlugin {
@@ -35,13 +31,8 @@ public class ProjectKorraRPG extends JavaPlugin {
 		new AvatarCommand();
 		new EventCommand();
 		new HelpCommand();
-		
-		if (this.getDataFolder() != null) {
-			if (new File(this.getDataFolder(), "projectkorra.db").exists()) {
-				importDatabase();
-			}
-		}
-		
+
+		connectToDatabase();
 		
 		Bukkit.getServer().getPluginManager().registerEvents(new RPGListener(), this);
 		Bukkit.getServer().getScheduler().scheduleSyncRepeatingTask(plugin, new EventManager(), 0L, 1L);
@@ -60,44 +51,11 @@ public class ProjectKorraRPG extends JavaPlugin {
 		// Might do something later
 	}
 	
-	public void importDatabase() {
+	public void connectToDatabase() {
 		DBConnection.open();
-		ProjectKorraRPG.log.info("Attempting to connect to the database.");
-		
 		if (!DBConnection.isOpen()) {
-			ProjectKorraRPG.log.info("Failed to connect to the database.");
 			return;
 		}
-		if (!DBConnection.sql.tableExists("pk_avatars")) {
-			ProjectKorraRPG.log.info("Table no longer exists, import aborted.");
-			DBConnection.close();
-			return;
-		}
-		ConcurrentHashMap<String, String> avatars = new ConcurrentHashMap<>();
-		ResultSet rs = DBConnection.sql.readQuery("SELECT * FROM pk_avatars WHERE uuid IS NOT NULL");
-		
-		try {
-			while (rs.next()) {
-				String uuid = rs.getString(2);
-				String elements = rs.getString(4);
-				avatars.putIfAbsent(uuid, elements);
-			}
-		}
-		catch (SQLException e) {
-			e.printStackTrace();
-			ProjectKorraRPG.log.info("Exception occured. Database closed.");
-			DBConnection.close();
-			return;
-		}
-		
-		for (String uuid : avatars.keySet()) {
-			String elements = avatars.get(uuid);
-			if (ConfigManager.avatarConfig.get().contains("Avatar.Past." + uuid))
-				ConfigManager.avatarConfig.get().set("Avatar.Past." + uuid, elements);
-		}
-		
-		ConfigManager.avatarConfig.save();
-		ProjectKorraRPG.log.info("Import successful, Database closed.");
-		DBConnection.close();
+		DBConnection.init();
 	}
 }

--- a/src/com/projectkorra/rpg/RPGListener.java
+++ b/src/com/projectkorra/rpg/RPGListener.java
@@ -9,6 +9,8 @@ import com.projectkorra.rpg.event.FullMoonEvent;
 import com.projectkorra.rpg.event.LunarEclipseEvent;
 import com.projectkorra.rpg.event.SolarEclipseEvent;
 import com.projectkorra.rpg.event.SozinsCometEvent;
+import com.projectkorra.rpg.event.WorldSunRiseEvent;
+import com.projectkorra.rpg.event.WorldSunSetEvent;
 
 import org.bukkit.World;
 import org.bukkit.block.BlockFace;
@@ -48,12 +50,17 @@ public class RPGListener implements Listener{
 
 	@EventHandler(priority = EventPriority.MONITOR)
 	public void onFullMoon(FullMoonEvent event) {
-		if (event.isCancelled()) return;
+		if (event.isCancelled())
+			return;
 		World world = event.getWorld();
+		if (EventManager.skipper.get(world)) {
+			EventManager.skipper.put(world, false);
+			return;
+		}
 		EventManager.marker.put(world, "FullMoon");
 		for (Player player : world.getPlayers()) {
 			BendingPlayer bPlayer = BendingPlayer.getBendingPlayer(player);
-			if (bPlayer != null && bPlayer.hasElement(Element.WATER) && bPlayer.isElementToggled(Element.WATER)) {
+			if (bPlayer != null && bPlayer.hasElement(Element.WATER)) {
 				if (player.hasPermission("bending.message.nightmessage")) {
 					player.sendMessage(Element.ICE.getColor() + event.getMessage());
 				}
@@ -63,12 +70,17 @@ public class RPGListener implements Listener{
 
 	@EventHandler(priority = EventPriority.MONITOR)
 	public void onLunarEclipse(LunarEclipseEvent event) {
-		if (event.isCancelled()) return;
+		if (event.isCancelled())
+			return;
 		World world = event.getWorld();
+		if (EventManager.skipper.get(world)) {
+			EventManager.skipper.put(world, false);
+			return;
+		}
 		EventManager.marker.put(world, "LunarEclipse");
 		for (Player player : world.getPlayers()) {
 			BendingPlayer bPlayer = BendingPlayer.getBendingPlayer(player);
-			if (bPlayer != null && bPlayer.hasElement(Element.WATER) && bPlayer.isElementToggled(Element.WATER)) {
+			if (bPlayer != null && bPlayer.hasElement(Element.WATER)) {
 				if (player.hasPermission("bending.message.nightmessage")) {
 					player.sendMessage(Element.WATER.getColor() + event.getMessage());
 				}
@@ -78,12 +90,17 @@ public class RPGListener implements Listener{
 
 	@EventHandler(priority = EventPriority.MONITOR)
 	public void onSolarEclipse(SolarEclipseEvent event) {
-		if (event.isCancelled()) return;
+		if (event.isCancelled())
+			return;
 		World world = event.getWorld();
+		if (EventManager.skipper.get(world)) {
+			EventManager.skipper.put(world, false);
+			return;
+		}
 		EventManager.marker.put(world, "SolarEclipse");
 		for (Player player : world.getPlayers()) {
 			BendingPlayer bPlayer = BendingPlayer.getBendingPlayer(player);
-			if (bPlayer != null && bPlayer.hasElement(Element.FIRE) && bPlayer.isElementToggled(Element.FIRE)) {
+			if (bPlayer != null && bPlayer.hasElement(Element.FIRE)) {
 				if (player.hasPermission("bending.message.daymessage")) {
 					player.sendMessage(Element.FIRE.getColor() + event.getMessage());
 				}
@@ -93,16 +110,47 @@ public class RPGListener implements Listener{
 
 	@EventHandler(priority = EventPriority.MONITOR)
 	public void onSozinsComet(SozinsCometEvent event) {
-		if (event.isCancelled()) return;
+		if (event.isCancelled())
+			return;
 		World world = event.getWorld();
+		if (EventManager.skipper.get(world)) {
+			EventManager.skipper.put(world, false);
+			return;
+		}
 		EventManager.marker.put(world, "SozinsComet");
 		for (Player player : world.getPlayers()) {
 			BendingPlayer bPlayer = BendingPlayer.getBendingPlayer(player);
-			if (bPlayer != null && bPlayer.hasElement(Element.FIRE) && bPlayer.isElementToggled(Element.FIRE)) {
+			if (bPlayer != null && bPlayer.hasElement(Element.FIRE)) {
 				if (player.hasPermission("bending.message.daymessage")) {
 					player.sendMessage(Element.COMBUSTION.getColor() + event.getMessage());
 				}
 			}
+		}
+	}
+
+	@EventHandler
+	public void onSunRise(WorldSunRiseEvent event) {
+		if (RPGMethods.isHappening(event.getWorld(), "FullMoon") || RPGMethods.isHappening(event.getWorld(), "LunarEclipse")) {
+			EventManager.marker.put(event.getWorld(), "");
+		}
+
+		if (RPGMethods.isSozinsComet(event.getWorld())) {
+			ProjectKorraRPG.plugin.getServer().getPluginManager().callEvent(new SozinsCometEvent(event.getWorld()));
+		} else if (RPGMethods.isSolarEclipse(event.getWorld())) {
+			ProjectKorraRPG.plugin.getServer().getPluginManager().callEvent(new SolarEclipseEvent(event.getWorld()));
+		}
+	}
+
+	@EventHandler
+	public void onSunSet(WorldSunSetEvent event) {
+		if (RPGMethods.isHappening(event.getWorld(), "SolarEclipse") || RPGMethods.isHappening(event.getWorld(), "SozinsComet")) {
+			EventManager.marker.put(event.getWorld(), "");
+		}
+
+		if (RPGMethods.isLunarEclipse(event.getWorld())) {
+			ProjectKorraRPG.plugin.getServer().getPluginManager().callEvent(new LunarEclipseEvent(event.getWorld()));
+		} else if (RPGMethods.isFullMoon(event.getWorld())) {
+			ProjectKorraRPG.plugin.getServer().getPluginManager().callEvent(new FullMoonEvent(event.getWorld()));
 		}
 	}
 	

--- a/src/com/projectkorra/rpg/RPGMethods.java
+++ b/src/com/projectkorra/rpg/RPGMethods.java
@@ -18,14 +18,46 @@ import java.util.List;
 import java.util.UUID;
 
 public class RPGMethods {
-	
+
+	/**
+	 * Checks every event interval for an event
+	 * 
+	 * @param world World being checked for an event
+	 * @return true if event interval is found
+	 */
+	public static boolean checkEveryInterval(World world) {
+		if (isFullMoon(world))
+			return true;
+		if (isLunarEclipse(world))
+			return true;
+		if (isSolarEclipse(world))
+			return true;
+		if (isSozinsComet(world))
+			return true;
+		return false;
+	}
+
+	/**
+	 * Checks for if the next event in the world is being skipped
+	 * 
+	 * @param world World being checked
+	 * @return true if being skipped
+	 */
+	public static boolean isBeingSkipped(World world) {
+		if (EventManager.skipper == null)
+			return false;
+		return EventManager.skipper.get(world);
+	}
+
 	/**
 	 * Returns false if the world event isn't enabled
-	 * @param world World being checked. 
+	 * 
+	 * @param world World being checked.
 	 * @return if FullMoon frequency lines up
 	 */
 	public static boolean isFullMoon(World world) {
-		if (!getEnabled("FullMoon")) return false;
+		if (!getEnabled("FullMoon"))
+			return false;
 		long days = world.getFullTime() / 24000;
 		long phase = days % getFrequency("FullMoon");
 		if (phase == 0) {
@@ -41,71 +73,87 @@ public class RPGMethods {
 	 * @return if param worldevent is happening in param world
 	 */
 	public static boolean isHappening(World world, String worldevent) {
-		if (EventManager.marker.get(world) == null) return false;
-		if (EventManager.marker.get(world) == "") return false;
-		if (EventManager.marker.get(world).equalsIgnoreCase(worldevent)) return true;
+		if (EventManager.marker.get(world) == null)
+			return false;
+		if (EventManager.marker.get(world) == "")
+			return false;
+		if (EventManager.marker.get(world).equalsIgnoreCase(worldevent))
+			return true;
 		return false;
 	}
-	
+
 	/**
 	 * Checks if an event is happening in the provided world
-	 * @param world
-	 * @return
+	 * 
+	 * @param world World being checked
+	 * @return whether there is an event happening or not
 	 */
 	public static boolean isEventHappening(World world) {
-		if (EventManager.marker.get(world) == null) return false;
-		if (EventManager.marker.get(world) == "") return false;
+		if (EventManager.marker.get(world) == null)
+			return false;
+		if (EventManager.marker.get(world) == "")
+			return false;
 		return true;
 	}
-	
-	/**
-	 * Returns false if the world event isn't enabled
-	 * @param world World being checked. 
-	 * @return if SozinsComet frequency lines up
-	 */
-	public static boolean isSozinsComet(World world) {
-		String comet = "SozinsComet";
-		if (!getEnabled(comet)) return false;
-		int freq = getFrequency(comet);
-
-		long days = (world.getFullTime() + 500) / 24000;
-		if (days%freq == 0) return true;
-		return false;
-	}
 
 	/**
 	 * Returns false if the world event isn't enabled
-	 * @param world World being checked. 
+	 * 
+	 * @param world World being checked.
 	 * @return if LunarEclipse frequency lines up
 	 */
 	public static boolean isLunarEclipse(World world) {
 		String eclipse = "LunarEclipse";
-		if (!getEnabled(eclipse)) return false;
+		if (!getEnabled(eclipse))
+			return false;
 		int freq = getFrequency(eclipse);
 
 		long days = (world.getFullTime() + 500) / 24000;
-		if (days%freq == 0) return true;
+		if (days % freq == 0)
+			return true;
 		return false;
 	}
-	
+
 	/**
 	 * Returns false if the world event isn't enabled
-	 * @param world World being checked. 
+	 * 
+	 * @param world World being checked.
 	 * @return if SolarEclipse frequency lines up
 	 */
 	public static boolean isSolarEclipse(World world) {
 		String eclipse = "SolarEclipse";
-		if (!getEnabled(eclipse)) return false;
+		if (!getEnabled(eclipse))
+			return false;
 		int freq = getFrequency(eclipse);
 
 		long days = (world.getFullTime() + 500) / 24000;
-		if (days%freq == 0) return true;
+		if (days % freq == 0)
+			return true;
+		return false;
+	}
+
+	/**
+	 * Returns false if the world event isn't enabled
+	 * 
+	 * @param world World being checked.
+	 * @return if SozinsComet frequency lines up
+	 */
+	public static boolean isSozinsComet(World world) {
+		String comet = "SozinsComet";
+		if (!getEnabled(comet))
+			return false;
+		int freq = getFrequency(comet);
+
+		long days = (world.getFullTime() + 500) / 24000;
+		if (days % freq == 0)
+			return true;
 		return false;
 	}
 
 	/**
 	 * 
-	 * @param we World Event. Choices are LunarEclipse, SolarEclipse, SozinsComet, and FullMoon
+	 * @param we World Event. Choices are LunarEclipse, SolarEclipse,
+	 *            SozinsComet, and FullMoon
 	 * @return boolean of if param we is enabled
 	 */
 	public static boolean getEnabled(String we) {
@@ -114,7 +162,8 @@ public class RPGMethods {
 
 	/**
 	 * 
-	 * @param we World Event. Choices are LunarEclipse, SolarEclipse, SozinsComet, and FullMoon
+	 * @param we World Event. Choices are LunarEclipse, SolarEclipse,
+	 *            SozinsComet, and FullMoon
 	 * @return int of frequency for param we
 	 */
 	public static int getFrequency(String we) {
@@ -125,7 +174,8 @@ public class RPGMethods {
 
 	/**
 	 * 
-	 * @param we World event. Choices are LunarEclipse, SolarEclipse, SozinsComet, and FullMoon
+	 * @param we World event. Choices are LunarEclipse, SolarEclipse,
+	 *            SozinsComet, and FullMoon
 	 * @return double of factor for param we
 	 */
 	public static double getFactor(String we) {
@@ -133,9 +183,10 @@ public class RPGMethods {
 			return 0;
 		return ConfigManager.rpgConfig.get().getDouble("WorldEvents." + we + ".Factor");
 	}
-	
+
 	/**
 	 * Randomly assigns an element to the param player if enabled in the config
+	 * 
 	 * @param player BendingPlayer being assigned an element to
 	 */
 	public static void randomAssign(BendingPlayer player) {
@@ -146,8 +197,8 @@ public class RPGMethods {
 		double waterchance = ConfigManager.rpgConfig.get().getDouble("ElementAssign.Percentages.Water");
 		double chichance = ConfigManager.rpgConfig.get().getDouble("ElementAssign.Percentages.Chi");
 
-		if(ConfigManager.rpgConfig.get().getBoolean("ElementAssign.Enabled")) {
-			if (rand < earthchance ) {
+		if (ConfigManager.rpgConfig.get().getBoolean("ElementAssign.Enabled")) {
+			if (rand < earthchance) {
 				assignElement(player, Element.EARTH, false);
 				return;
 			}
@@ -174,20 +225,24 @@ public class RPGMethods {
 		} else {
 			String defaultElement = ConfigManager.rpgConfig.get().getString("ElementAssign.Default");
 			Element e = Element.EARTH;
-			
-			if(defaultElement.equalsIgnoreCase("None")) {
+
+			if (defaultElement.equalsIgnoreCase("None")) {
 				return;
 			}
 
-			if(defaultElement.equalsIgnoreCase("Chi")) {
+			if (defaultElement.equalsIgnoreCase("Chi")) {
 				assignElement(player, Element.CHI, true);
 				return;
 			}
 
-			if(defaultElement.equalsIgnoreCase("Water")) e = Element.WATER;
-			if(defaultElement.equalsIgnoreCase("Earth")) e = Element.EARTH;
-			if(defaultElement.equalsIgnoreCase("Fire")) e = Element.FIRE;
-			if(defaultElement.equalsIgnoreCase("Air")) e = Element.AIR;
+			if (defaultElement.equalsIgnoreCase("Water"))
+				e = Element.WATER;
+			if (defaultElement.equalsIgnoreCase("Earth"))
+				e = Element.EARTH;
+			if (defaultElement.equalsIgnoreCase("Fire"))
+				e = Element.FIRE;
+			if (defaultElement.equalsIgnoreCase("Air"))
+				e = Element.AIR;
 
 			assignElement(player, e, false);
 			return;
@@ -195,26 +250,34 @@ public class RPGMethods {
 	}
 
 	/**
-	 * Sets the player's element as param e, sending a message on what they became.
+	 * Sets the player's element as param e, sending a message on what they
+	 * became.
+	 * 
 	 * @param player BendingPlayer which the element is being added to
 	 * @param e Element being added to the player
-	 * @param chiblocker if the player is becoming a chiblocker 
+	 * @param chiblocker if the player is becoming a chiblocker
 	 */
 	private static void assignElement(BendingPlayer player, Element e, Boolean chiblocker) {
 		player.setElement(e);
 		GeneralMethods.saveElements(player);
-		if(!chiblocker) {
-			if(e.toString().equalsIgnoreCase("Earth")) Bukkit.getPlayer(player.getUUID()).sendMessage(ChatColor.WHITE + "You have been born as an " + ChatColor.GREEN + e.toString() + "bender!");
-			if(e.toString().equalsIgnoreCase("Fire")) Bukkit.getPlayer(player.getUUID()).sendMessage(ChatColor.WHITE + "You have been born as a " + ChatColor.RED + e.toString() + "bender!");
-			if(e.toString().equalsIgnoreCase("Water")) Bukkit.getPlayer(player.getUUID()).sendMessage(ChatColor.WHITE + "You have been born as a " + ChatColor.AQUA + e.toString() + "bender!");
-			if(e.toString().equalsIgnoreCase("Air")) Bukkit.getPlayer(player.getUUID()).sendMessage(ChatColor.WHITE + "You have been born as an " + ChatColor.GRAY + e.toString() + "bender!");
-		}else{
+		if (!chiblocker) {
+			if (e.toString().equalsIgnoreCase("Earth"))
+				Bukkit.getPlayer(player.getUUID()).sendMessage(ChatColor.WHITE + "You have been born as an " + ChatColor.GREEN + e.toString() + "bender!");
+			if (e.toString().equalsIgnoreCase("Fire"))
+				Bukkit.getPlayer(player.getUUID()).sendMessage(ChatColor.WHITE + "You have been born as a " + ChatColor.RED + e.toString() + "bender!");
+			if (e.toString().equalsIgnoreCase("Water"))
+				Bukkit.getPlayer(player.getUUID()).sendMessage(ChatColor.WHITE + "You have been born as a " + ChatColor.AQUA + e.toString() + "bender!");
+			if (e.toString().equalsIgnoreCase("Air"))
+				Bukkit.getPlayer(player.getUUID()).sendMessage(ChatColor.WHITE + "You have been born as an " + ChatColor.GRAY + e.toString() + "bender!");
+		} else {
 			Bukkit.getPlayer(player.getUUID()).sendMessage(ChatColor.WHITE + "You have been raised as a " + ChatColor.GOLD + "Chiblocker!");
 		}
 	}
-	
+
 	/**
-	 * Sets a player to the avatar giving them all the elements (excluding chiblocking) and the extra perks such as almost death avatarstate.  
+	 * Sets a player to the avatar giving them all the elements (excluding
+	 * chiblocking) and the extra perks such as almost death avatarstate.
+	 * 
 	 * @param uuid UUID of player being set as the avatar
 	 */
 	public static void setAvatar(UUID uuid) {
@@ -228,8 +291,9 @@ public class RPGMethods {
 		StringBuilder sb = new StringBuilder();
 		int i = 0;
 		for (Element e : bPlayer.getElements()) {
-			if (e instanceof SubElement) continue;
-			
+			if (e instanceof SubElement)
+				continue;
+
 			if (bPlayer.getElements().size() - 1 == i) {
 				sb.append(e.toString());
 			} else {
@@ -248,7 +312,9 @@ public class RPGMethods {
 	}
 
 	/**
-	 * Checks if player with uuid is they current avatar. Returns null if there is no current avatar
+	 * Checks if player with uuid is they current avatar. Returns null if there
+	 * is no current avatar
+	 * 
 	 * @param uuid UUID of player being checked
 	 * @return if player with uuid is the current avatar
 	 */
@@ -264,25 +330,33 @@ public class RPGMethods {
 	}
 
 	/**
-	 * Checks if the player with uuid has been the avatar. Returns true if player is current avatar
+	 * Checks if the player with uuid has been the avatar. Returns true if
+	 * player is current avatar
+	 * 
 	 * @param uuid UUID of player being checked
 	 * @return if player with uuid has been the avatar
 	 */
 	public static boolean hasBeenAvatar(UUID uuid) {
-		if (isCurrentAvatar(uuid)) return true;
-		if (ConfigManager.avatarConfig.get().contains("Avatar.Past." + uuid.toString())) return true;
+		if (isCurrentAvatar(uuid))
+			return true;
+		if (ConfigManager.avatarConfig.get().contains("Avatar.Past." + uuid.toString()))
+			return true;
 		return false;
 	}
-	
+
 	/**
-	 * Removes the rpg avatar permissions for the player with the matching uuid, if they are the current avatar
+	 * Removes the rpg avatar permissions for the player with the matching uuid,
+	 * if they are the current avatar
+	 * 
 	 * @param uuid UUID of player being checked
 	 */
 	public static void revokeAvatar(UUID uuid) {
-		if (!isCurrentAvatar(uuid)) return;
+		if (!isCurrentAvatar(uuid))
+			return;
 		List<Element> elements = new ArrayList<>();
 		BendingPlayer bPlayer = BendingPlayer.getBendingPlayer(Bukkit.getPlayer(uuid));
-		if (bPlayer == null) return;
+		if (bPlayer == null)
+			return;
 		for (String s : ConfigManager.avatarConfig.get().getString("Avatar.Past." + uuid.toString()).split(":")) {
 			elements.add(Element.fromString(s));
 		}

--- a/src/com/projectkorra/rpg/commands/AvatarCommand.java
+++ b/src/com/projectkorra/rpg/commands/AvatarCommand.java
@@ -1,6 +1,5 @@
 package com.projectkorra.rpg.commands;
 
-import com.projectkorra.projectkorra.command.PKCommand;
 import com.projectkorra.rpg.RPGMethods;
 
 import org.bukkit.Bukkit;
@@ -10,7 +9,7 @@ import org.bukkit.entity.Player;
 
 import java.util.List;
 
-public class AvatarCommand extends PKCommand{
+public class AvatarCommand extends RPGCommand{
 
 	public AvatarCommand() {
 		super("avatar", "/bending avatar [player]", "This command defines a player as the avatar and gives them all the elements and other perks.", new String[] {"avatar", "av", "avy"});

--- a/src/com/projectkorra/rpg/commands/EventCommand.java
+++ b/src/com/projectkorra/rpg/commands/EventCommand.java
@@ -3,7 +3,6 @@ package com.projectkorra.rpg.commands;
 import com.projectkorra.projectkorra.Element;
 import com.projectkorra.projectkorra.ProjectKorra;
 import com.projectkorra.projectkorra.ability.WaterAbility;
-import com.projectkorra.projectkorra.command.PKCommand;
 import com.projectkorra.rpg.RPGMethods;
 import com.projectkorra.rpg.event.EventManager;
 import com.projectkorra.rpg.event.FullMoonEvent;
@@ -16,12 +15,19 @@ import org.bukkit.World;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
+import java.util.Arrays;
 import java.util.List;
 
-public class EventCommand extends PKCommand{
+public class EventCommand extends RPGCommand {
+	
+	private String[] help = {"help", "h", "?"};
+	private String[] current = {"current", "curr", "c"};
+	private String[] end = {"end", "e", "cancel", "remove"};
+	private String[] skip = {"skip", "sk"};
+	private String[] start = {"start", "st", "strt", "begin"};
 
 	public EventCommand() {
-		super("worldevent", "/bending worldevent help|start|current [worldevent]", "Main command for anything dealing with RPG world events.", new String[] {"worldevent", "worlde", "event", "we"});
+		super("worldevent", "/bending worldevent <help/ current / end / skip / (start <worldevent>)>", "Main command for anything dealing with RPG world events.", new String[] { "worldevent", "worlde", "event", "we" });
 	}
 
 	@Override
@@ -31,30 +37,47 @@ public class EventCommand extends PKCommand{
 		} else if (args.size() == 1) {
 			if (!hasPermission(sender)) {
 				return;
-			} else if (args.get(0).equalsIgnoreCase("help")) {
+			} else if (Arrays.asList(help).contains(args.get(0).toLowerCase())) {
 				sender.sendMessage(ChatColor.YELLOW + getDescription());
 				sender.sendMessage(ChatColor.YELLOW + "WorldEvents:");
-				sender.sendMessage(Element.ICE.getColor() + "FullMoon");
-				sender.sendMessage(Element.WATER.getColor() + "LunarEclipse");
-				sender.sendMessage(Element.FIRE.getColor() + "SolarEclipse");
-				sender.sendMessage(Element.COMBUSTION.getColor() + "SozinsComet");
-			} else if (args.get(0).equalsIgnoreCase("current")) {
-				if (!isPlayer(sender)) return;
-				Player player = (Player)sender;
-				if (!EventManager.getMarker().containsKey(player.getWorld()) || EventManager.getMarker().get(player.getWorld()) == "") {
+				sender.sendMessage(Element.ICE.getColor() + "FullMoon - Makes Waterbending super enhanced");
+				sender.sendMessage(Element.WATER.getColor() + "LunarEclipse - Makes Waterbending useless");
+				sender.sendMessage(Element.FIRE.getColor() + "SolarEclipse - Makes Firebending useless");
+				sender.sendMessage(Element.COMBUSTION.getColor() + "SozinsComet - Makes Firebending super enhanced");
+			} else if (Arrays.asList(current).contains(args.get(0).toLowerCase())) {
+				if (!isPlayer(sender))
+					return;
+				Player player = (Player) sender;
+				if (!EventManager.marker.containsKey(player.getWorld()) || EventManager.marker.get(player.getWorld()) == "") {
 					sender.sendMessage(ChatColor.RED + "There are no current world events happening in this world.");
 				} else {
-					sender.sendMessage(ChatColor.YELLOW + "Current event: " + EventManager.getMarker().get(player.getWorld()));
+					sender.sendMessage(ChatColor.YELLOW + "Current event: " + EventManager.marker.get(player.getWorld()));
 				}
+			} else if (Arrays.asList(end).contains(args.get(0).toLowerCase())) {
+				if (!isPlayer(sender))
+					return;
+				Player player = (Player) sender;
+				if (!EventManager.marker.containsKey(player.getWorld()) || EventManager.marker.get(player.getWorld()) == "") {
+					sender.sendMessage(ChatColor.RED + "There is no event to end at the moment.");
+				} else {
+					EventManager.endEvent(player.getWorld());
+					sender.sendMessage(ChatColor.GREEN + "The event occupying this world has been ended.");
+				}
+			} else if (Arrays.asList(skip).contains(args.get(0).toLowerCase())) {
+				if (!isPlayer(sender))
+					return;
+				Player player = (Player) sender;
+				EventManager.skipper.put(player.getWorld(), true);
+				sender.sendMessage(ChatColor.GREEN + "The next worldevent will be skipped.");
 			}
 		} else if (args.size() == 2) {
 			if (!hasPermission(sender)) {
 				return;
-			} else if (args.get(0).equalsIgnoreCase("start")) {
+			} else if (Arrays.asList(start).contains(args.get(0).toLowerCase())) {
 				if (!isPlayer(sender)) {
 					return;
 				}
-				Player player = (Player)sender;
+				Player player = (Player) sender;
 				if (player.getWorld().getEnvironment().equals(World.Environment.NETHER) || player.getWorld().getEnvironment().equals(World.Environment.THE_END)) {
 					player.sendMessage(ChatColor.RED + "Cannot start an Event in this world type!");
 					return;

--- a/src/com/projectkorra/rpg/commands/HelpCommand.java
+++ b/src/com/projectkorra/rpg/commands/HelpCommand.java
@@ -1,0 +1,61 @@
+package com.projectkorra.rpg.commands;
+
+import com.projectkorra.projectkorra.Element;
+
+import org.bukkit.ChatColor;
+import org.bukkit.command.CommandSender;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class HelpCommand extends RPGCommand{
+	
+	private String[] fullmoon = {"fullmoon", "fm", "fmoon", "fullm"}; 
+	private String[] lunar = {"lunareclipse", "le", "leclipse", "lunare"}; 
+	private String[] solar = {"solareclipse", "se", "seclipse", "solare"}; 
+	private String[] sozins = {"sozinscomet", "sc", "sozins", "sozinsc", "scomet", "comet"}; 
+	private String[] avatar = {"avatar", "avy", "av"};
+	private String modifiers = ChatColor.BLUE + "Command Modifiers : [] - optional : <> - required : () - together";
+
+	public HelpCommand() {
+		super("help", "/bending rpg help [topic]", "Shows all helpful information for rpg", new String[] {"help", "h", "?"});
+	}
+
+	@Override
+	public void execute(CommandSender sender, List<String> args) {
+		if (!correctLength(sender, args.size(), 0, 1)) {
+			return;
+		}
+		
+		StringBuilder help = new StringBuilder(modifiers);
+		for (RPGCommand command : RPGCommand.instances.values()) {
+			help.append(ChatColor.YELLOW + "\n" + command.getProperUse() + " - " + command.getDescription());
+		}
+		
+		if (args.size() == 0) {
+			sender.sendMessage(help.toString());
+		} else if (args.size() == 1) {
+			if (Arrays.asList(fullmoon).contains(args.get(0).toLowerCase())) {
+				if (!hasPermission(sender, fullmoon[1]))
+					return;
+				sender.sendMessage(Element.ICE.getColor() + "Full Moon - This is a world event in which the moon is full, enhancing the power of waterbending by a large amount.");
+			} else if (Arrays.asList(lunar).contains(args.get(0).toLowerCase())) {
+				if (!hasPermission(sender, lunar[1]))
+					return;
+				sender.sendMessage(Element.WATER.getColor() + "Lunar Eclipse - This is a world event in which the moon is unable to be seen in the night sky, causing waterbending to lose all it's power.");				
+			} else if (Arrays.asList(solar).contains(args.get(0).toLowerCase())) {
+				if (!hasPermission(sender, solar[1]))
+					return;
+				sender.sendMessage(Element.FIRE.getColor() + "Solar Eclipse - This is a world event in which the sun is unable to be seen in the day sky, causing firebending to lose all it's power.");				
+			} else if (Arrays.asList(sozins).contains(args.get(0).toLowerCase())) {
+				if (!hasPermission(sender, sozins[1]))
+					return;
+				sender.sendMessage(Element.COMBUSTION.getColor() + "Sozins Comet - This is a world event in which a comet passes by the earth, enhancing firebending by a large amount.");				
+			} else if (Arrays.asList(avatar).contains(args.get(0).toLowerCase())) {
+				if (!hasPermission(sender, avatar[1]))
+					return;
+				sender.sendMessage(Element.AVATAR.getColor() + "Avatar - The avatar is the only bender who can wield all the elements. He or she is the bridge between the spirit and physical world, keeping balance in the physical world. The avatar is the most powerful bender, and the cycle for which element is to be the next avatar goes Fire, Air, Water, Earth, starting with the first firebending avatar, Wan");				
+			}
+		}
+	}
+}

--- a/src/com/projectkorra/rpg/commands/IRPGCommand.java
+++ b/src/com/projectkorra/rpg/commands/IRPGCommand.java
@@ -1,0 +1,10 @@
+package com.projectkorra.rpg.commands;
+
+import org.bukkit.command.CommandSender;
+
+import java.util.List;
+
+public interface IRPGCommand {
+
+	public void execute(CommandSender sender, List<String> args);
+}

--- a/src/com/projectkorra/rpg/commands/RPGCommand.java
+++ b/src/com/projectkorra/rpg/commands/RPGCommand.java
@@ -1,0 +1,121 @@
+package com.projectkorra.rpg.commands;
+
+import com.projectkorra.projectkorra.command.PKCommand;
+
+import org.bukkit.ChatColor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import java.util.HashMap;
+
+public abstract class RPGCommand implements IRPGCommand{
+	
+	public static HashMap<String, RPGCommand> instances = new HashMap<>();
+
+	private String name;
+	private String properUse;
+	private String description;
+	private String[] aliases;
+	
+	public RPGCommand(String name, String properUse, String description, String[] aliases) {
+		this.name = name;
+		this.properUse = properUse;
+		this.description = description;
+		this.aliases = aliases;
+		instances.put(name, this);
+	}
+	
+	public String getName() {
+		return name;
+	}
+	
+	public String getProperUse() {
+		return properUse;
+	}
+	
+	public String getDescription() {
+		return description;
+	}
+	
+	public String[] getAliases() {
+		return aliases;
+	}
+	
+
+	public void help(CommandSender sender, boolean description) {
+		sender.sendMessage(ChatColor.GOLD + "Proper Usage: " + ChatColor.DARK_AQUA + properUse);
+		if (description) {
+			sender.sendMessage(ChatColor.YELLOW + this.description);
+		}
+	}
+
+	/**
+	 * Checks if the {@link CommandSender} has permission to execute the
+	 * command. The permission is in the format 'bending.command.
+	 * {@link PKCommand#name name}'. If not, they are told so.
+	 * 
+	 * @param sender The CommandSender to check
+	 * @return True if they have permission, false otherwise
+	 */
+	protected boolean hasPermission(CommandSender sender) {
+		if (sender.hasPermission("bending.command.rpg." + name)) {
+			return true;
+		} else {
+			sender.sendMessage(ChatColor.RED + "You don't have permission to do that.");
+			return false;
+		}
+	}
+
+	/**
+	 * Checks if the {@link CommandSender} has permission to execute the
+	 * command. The permission is in the format 'bending.command.
+	 * {@link PKCommand#name name}.extra'. If not, they are told so.
+	 * 
+	 * @param sender The CommandSender to check
+	 * @param extra The additional node to check
+	 * @return True if they have permission, false otherwise
+	 */
+	protected boolean hasPermission(CommandSender sender, String extra) {
+		if (sender.hasPermission("bending.command.rpg." + name + "." + extra)) {
+			return true;
+		} else {
+			sender.sendMessage(ChatColor.RED + "You don't have permission to do that.");
+			return false;
+		}
+	}
+
+	/**
+	 * Checks if the argument length is within certain parameters, and if not,
+	 * informs the CommandSender of how to correctly use the command.
+	 * 
+	 * @param sender The CommandSender who issued the command
+	 * @param size The length of the arguments list
+	 * @param min The minimum acceptable number of arguments
+	 * @param max The maximum acceptable number of arguments
+	 * @return True if min < size < max, false otherwise
+	 */
+	protected boolean correctLength(CommandSender sender, int size, int min, int max) {
+		if (size < min || size > max) {
+			help(sender, false);
+			return false;
+		} else {
+			return true;
+		}
+	}
+
+	/**
+	 * Checks if the CommandSender is an instance of a Player. If not, it tells
+	 * them they must be a Player to use the command.
+	 * 
+	 * @param sender The CommandSender to check
+	 * @return True if sender instanceof Player, false otherwise
+	 */
+	protected boolean isPlayer(CommandSender sender) {
+		if (sender instanceof Player) {
+			return true;
+		} else {
+			sender.sendMessage(ChatColor.RED + "You must be a player to use that command.");
+			return false;
+		}
+	}
+}

--- a/src/com/projectkorra/rpg/commands/RPGCommandBase.java
+++ b/src/com/projectkorra/rpg/commands/RPGCommandBase.java
@@ -1,0 +1,30 @@
+package com.projectkorra.rpg.commands;
+
+import net.md_5.bungee.api.ChatColor;
+
+import com.projectkorra.projectkorra.command.PKCommand;
+
+import org.bukkit.command.CommandSender;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class RPGCommandBase extends PKCommand {
+
+	public RPGCommandBase() {
+		super("RPG", "/bending RPG", "Base command for the RPG side plugin", new String[] {"rpg"});
+	}
+
+	@Override
+	public void execute(CommandSender sender, List<String> args) {
+		if (args.size() == 0) {
+			sender.sendMessage(ChatColor.RED + "/bending rpg help");
+			return;
+		}
+		for (RPGCommand command : RPGCommand.instances.values()) {
+			if (Arrays.asList(command.getAliases()).contains(args.get(0).toLowerCase())) {
+				command.execute(sender, args.subList(1, args.size()));
+			}
+		}
+	}
+}

--- a/src/com/projectkorra/rpg/event/LunarEclipseEvent.java
+++ b/src/com/projectkorra/rpg/event/LunarEclipseEvent.java
@@ -1,6 +1,5 @@
 package com.projectkorra.rpg.event;
 
-import com.projectkorra.rpg.ProjectKorraRPG;
 import com.projectkorra.rpg.configuration.ConfigManager;
 
 import org.bukkit.World;

--- a/src/com/projectkorra/rpg/event/SolarEclipseEvent.java
+++ b/src/com/projectkorra/rpg/event/SolarEclipseEvent.java
@@ -1,6 +1,5 @@
 package com.projectkorra.rpg.event;
 
-import com.projectkorra.rpg.ProjectKorraRPG;
 import com.projectkorra.rpg.configuration.ConfigManager;
 
 import org.bukkit.World;

--- a/src/com/projectkorra/rpg/event/SozinsCometEvent.java
+++ b/src/com/projectkorra/rpg/event/SozinsCometEvent.java
@@ -1,6 +1,5 @@
 package com.projectkorra.rpg.event;
 
-import com.projectkorra.rpg.ProjectKorraRPG;
 import com.projectkorra.rpg.configuration.ConfigManager;
 
 import org.bukkit.World;

--- a/src/com/projectkorra/rpg/event/WorldSunRiseEvent.java
+++ b/src/com/projectkorra/rpg/event/WorldSunRiseEvent.java
@@ -1,0 +1,30 @@
+package com.projectkorra.rpg.event;
+
+import org.bukkit.World;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+
+public class WorldSunRiseEvent extends Event{
+	
+	private static final HandlerList handlers = new HandlerList();
+
+	private World world;
+	
+	public WorldSunRiseEvent(World world) {
+		this.world = world;
+	}
+	
+	public World getWorld() {
+		return world;
+	}
+	
+	@Override
+	public HandlerList getHandlers() {
+		// TODO Auto-generated method stub
+		return handlers;
+	}
+
+	public static HandlerList getHandlerList() {
+		return handlers;
+	}
+}

--- a/src/com/projectkorra/rpg/event/WorldSunSetEvent.java
+++ b/src/com/projectkorra/rpg/event/WorldSunSetEvent.java
@@ -1,0 +1,30 @@
+package com.projectkorra.rpg.event;
+
+import org.bukkit.World;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+
+public class WorldSunSetEvent extends Event{
+
+	private static final HandlerList handlers = new HandlerList();
+	
+	private World world;
+	
+	public WorldSunSetEvent(World world) {
+		this.world = world;
+	}
+	
+	public World getWorld() {
+		return world;
+	}
+	
+	@Override
+	public HandlerList getHandlers() {
+		// TODO Auto-generated method stub
+		return handlers;
+	}
+
+	public static HandlerList getHandlerList() {
+		return handlers;
+	}
+}

--- a/src/com/projectkorra/rpg/storage/DBConnection.java
+++ b/src/com/projectkorra/rpg/storage/DBConnection.java
@@ -1,5 +1,6 @@
 package com.projectkorra.rpg.storage;
 
+import com.projectkorra.projectkorra.ProjectKorra;
 import com.projectkorra.rpg.ProjectKorraRPG;
 
 public class DBConnection {
@@ -17,14 +18,19 @@ public class DBConnection {
 	public static void init() {
 		open();
 		if (!isOpen) return;
+		String createQuery = "CREATE TABLE pk_avatars (id INTEGER PRIMARY KEY, uuid %uuid%, player %player%, elements %elements%)";
+		if (host.equalsIgnoreCase("mysql")) {
+			createQuery = createQuery.replace("%uuid%", "varchar(255)");
+			createQuery = createQuery.replace("%player%", "varchar(255)");
+			createQuery = createQuery.replace("%elements%", "varchar(255)");
+		} else {
+			createQuery = createQuery.replace("%uuid%", "TEXT(255)");
+			createQuery = createQuery.replace("%player%", "TEXT(255)");
+			createQuery = createQuery.replace("%elements%", "TEXT(255)");
+		}
 		if (!sql.tableExists("pk_avatars")) {
 			ProjectKorraRPG.log.info("Creating pk_avatars table.");
-			String query = "CREATE TABLE `pk_avatars` ("
-					+ "`id` INTEGER PRIMARY KEY,"
-					+ "`uuid` TEXT(255),"
-					+ "`player` TEXT(255),"
-					+ "`element` TEXT(255));";
-			sql.modifyQuery(query);
+			sql.modifyQuery(createQuery);
 		}
 	}
 	
@@ -51,7 +57,7 @@ public class DBConnection {
 			isOpen = true;
 			ProjectKorraRPG.log.info("Database connection established.");
 		} else {
-			sql = new SQLite(ProjectKorraRPG.log, "Establishing SQLite Connection... ", "projectkorra.db", ProjectKorraRPG.plugin.getDataFolder().getAbsolutePath());
+			sql = new SQLite(ProjectKorraRPG.log, "Establishing SQLite Connection... ", "projectkorra_rpg.db", ProjectKorra.plugin.getDataFolder().getAbsolutePath());
 			if (((SQLite) sql).open() == null) {
 				ProjectKorraRPG.log.severe("Disabling due to database error");
 				return;

--- a/src/com/projectkorra/rpg/storage/DBConnection.java
+++ b/src/com/projectkorra/rpg/storage/DBConnection.java
@@ -15,52 +15,49 @@ public class DBConnection {
 	private static boolean isOpen;
 
 	public static void init() {
+		open();
+		if (!isOpen) return;
+		if (!sql.tableExists("pk_avatars")) {
+			ProjectKorraRPG.log.info("Creating pk_avatars table.");
+			String query = "CREATE TABLE `pk_avatars` ("
+					+ "`id` INTEGER PRIMARY KEY,"
+					+ "`uuid` TEXT(255),"
+					+ "`player` TEXT(255),"
+					+ "`element` TEXT(255));";
+			sql.modifyQuery(query);
+		}
+	}
+	
+	public static void close() {
+		isOpen = false;
+		sql.close();
+	}
+	
+	public static void open() {
 		engine = ProjectKorraRPG.plugin.getConfig().getString("Storage.engine");
 		host = ProjectKorraRPG.plugin.getConfig().getString("Storage.MySQL.host");
 		port = ProjectKorraRPG.plugin.getConfig().getInt("Storage.MySQL.port");
 		pass = ProjectKorraRPG.plugin.getConfig().getString("Storage.MySQL.pass");
 		db = ProjectKorraRPG.plugin.getConfig().getString("Storage.MySQL.db");
 		user = ProjectKorraRPG.plugin.getConfig().getString("Storage.MySQL.user");
+		if (isOpen) 
+			return;
 		if (engine.equalsIgnoreCase("mysql")) {
-			sql = new MySQL(ProjectKorraRPG.log, "[ProjectKorra] Establishing MySQL Connection... ", host, port, user, pass, db);
+			sql = new MySQL(ProjectKorraRPG.log, "Establishing MySQL Connection... ", host, port, user, pass, db);
 			if (((MySQL) sql).open() == null) {
-				ProjectKorraRPG.log.severe("Disabling due to database error");
+				ProjectKorraRPG.log.severe("Failed to open the database.");
 				return;
 			}
-
 			isOpen = true;
-			ProjectKorraRPG.log.info("[ProjectKorra] Database connection established.");
-
-			if (!sql.tableExists("pk_avatars")) {
-				ProjectKorraRPG.log.info("Creating pk_avatars table.");
-				String query = "CREATE TABLE `pk_avatars` ("
-						+ "`id` int(32) NOT NULL AUTO_INCREMENT,"
-						+ "`uuid` varchar(255),"
-						+ "`player` varchar(255),"
-						+ "`element` varchar(255),"
-						+ " PRIMARY KEY (id));";
-				sql.modifyQuery(query);
-			}
-			
+			ProjectKorraRPG.log.info("Database connection established.");
 		} else {
-			sql = new SQLite(ProjectKorraRPG.log, "[ProjectKorra] Establishing SQLite Connection... ", "projectkorra.db", ProjectKorraRPG.plugin.getDataFolder().getAbsolutePath());
+			sql = new SQLite(ProjectKorraRPG.log, "Establishing SQLite Connection... ", "projectkorra.db", ProjectKorraRPG.plugin.getDataFolder().getAbsolutePath());
 			if (((SQLite) sql).open() == null) {
 				ProjectKorraRPG.log.severe("Disabling due to database error");
 				return;
 			}
-
 			isOpen = true;
-			ProjectKorraRPG.log.info("[ProjectKorra] Database connection established.");
-
-			if (!sql.tableExists("pk_avatars")) {
-				ProjectKorraRPG.log.info("Creating pk_avatars table.");
-				String query = "CREATE TABLE `pk_avatars` ("
-						+ "`id` INTEGER PRIMARY KEY,"
-						+ "`uuid` TEXT(255),"
-						+ "`player` TEXT(255),"
-						+ "`element` TEXT(255));";
-				sql.modifyQuery(query);
-			}
+			ProjectKorraRPG.log.info("Database connection established.");
 		}
 	}
 	


### PR DESCRIPTION
WorldEvents:
- Added two new arguments to the command; end and skip. Both do as expected.
- Added check for if bending was all toggled. Players with fire or water toggled individually will still see the messages.
Events:
- Added WorldSunRiseEvent and WorldSunSetEvent
- The WorldEvents are now either called in one of the two latter events, respectively.
Storage:
- Changed the database to a yml file called RPG_avatars.yml, automatically imports the avatars from the database onto the new file
- Moved all yml files for rpg into the ProjectKorra folder. The ProjectKorraRPG folder now has no use unless importing a database which isn't required.
Commands:
- Reworked the rpg command system. It's basically the same system as core, but within the core system. All rpg commands will now look like /bending rpg <command> and have the permission bending.command.rpg.<command>
