### PR TITLE
Fix Problems with Event Concurrency

### DIFF
--- a/src/com/projectkorra/rpg/RPGListener.java
+++ b/src/com/projectkorra/rpg/RPGListener.java
@@ -136,7 +136,7 @@ public class RPGListener implements Listener {
 					continue;
 				}
 
-				ProjectKorraRPG.getEventManager().endEvent(event.getWorld(), wEvent);
+				ProjectKorraRPG.getEventManager().endEvent(event.getWorld(), wEvent, false);
 			} else if (wEvent.getTime() == Time.DAY || wEvent.getTime() == Time.BOTH) {
 				if (Math.ceil((event.getWorld().getFullTime() / 24000)) % wEvent.getFrequency() == 0) {
 					WorldEventStartEvent startEvent = new WorldEventStartEvent(event.getWorld(), wEvent);
@@ -157,7 +157,7 @@ public class RPGListener implements Listener {
 						continue;
 					}
 
-					ProjectKorraRPG.getEventManager().endEvent(event.getWorld(), wEvent);
+					ProjectKorraRPG.getEventManager().endEvent(event.getWorld(), wEvent, false);
 				}
 			}
 		}
@@ -186,7 +186,7 @@ public class RPGListener implements Listener {
 						continue;
 					}
 
-					ProjectKorraRPG.getEventManager().endEvent(event.getWorld(), wEvent);
+					ProjectKorraRPG.getEventManager().endEvent(event.getWorld(), wEvent, false);
 				}
 			}
 		}

--- a/src/com/projectkorra/rpg/RPGListener.java
+++ b/src/com/projectkorra/rpg/RPGListener.java
@@ -1,5 +1,7 @@
 package com.projectkorra.rpg;
 
+import java.lang.reflect.Field;
+
 import org.bukkit.Bukkit;
 import org.bukkit.World;
 import org.bukkit.block.BlockFace;
@@ -101,17 +103,16 @@ public class RPGListener implements Listener {
 				if (we.getModifier() <= 0) {
 					event.setCancelled(true);
 				} else {
-					if (!ability.getClass().isAnnotationPresent(Attribute.class)) {
-						continue;
-					}
-					
 					for (String attribute : we.getAttributes()) {
 						String[] split = attribute.split("::");
 						boolean passed = false;
-						for (Attribute a : ability.getClass().getAnnotationsByType(Attribute.class)) {
-							if (a.value().equalsIgnoreCase(split[0])) {
-								passed = true;
-								break;
+						
+						for (Field f : ability.getClass().getDeclaredFields()) {
+							if (f.isAnnotationPresent(Attribute.class)) {
+								if (f.getAnnotation(Attribute.class).value().equals(split[0])) {
+									passed = true;
+									break;
+								}
 							}
 						}
 						

--- a/src/com/projectkorra/rpg/commands/EventCommand.java
+++ b/src/com/projectkorra/rpg/commands/EventCommand.java
@@ -71,7 +71,7 @@ public class EventCommand extends RPGCommand {
 				sender.sendMessage(ChatColor.RED + "There is no WorldEvent to end at the moment.");
 			} else if (args.size() == 1) {
 				for (WorldEvent event : WorldEvent.getEvents()) {
-					ProjectKorraRPG.getEventManager().endEvent(world, event);
+					ProjectKorraRPG.getEventManager().endEvent(world, event, false);
 				}
 
 				sender.sendMessage(ChatColor.GOLD + "All WorldEvents have been ended!");
@@ -84,7 +84,7 @@ public class EventCommand extends RPGCommand {
 				} else if (!ProjectKorraRPG.getEventManager().isHappening(world, event)) {
 					sender.sendMessage(ChatColor.RED + "That event is currently not happening in this world!");
 				} else {
-					ProjectKorraRPG.getEventManager().endEvent(world, event);
+					ProjectKorraRPG.getEventManager().endEvent(world, event, false);
 					sender.sendMessage(ChatColor.GOLD + "You have ended the " + event.getName() + " event!");
 				}
 			}

--- a/src/com/projectkorra/rpg/commands/EventCommand.java
+++ b/src/com/projectkorra/rpg/commands/EventCommand.java
@@ -48,7 +48,7 @@ public class EventCommand extends RPGCommand {
 				sender.sendMessage(ChatColor.YELLOW + "Current WorldEvents: ");
 
 				for (WorldEvent event : ProjectKorraRPG.getEventManager().getEventsHappening(world)) {
-					sender.sendMessage(event.getElement().getColor() + "- " + event.getName());
+					sender.sendMessage(event.getTextColor() + "- " + event.getName());
 				}
 			} else if (args.size() == 2) {
 				String name = args.get(1);

--- a/src/com/projectkorra/rpg/commands/HelpCommand.java
+++ b/src/com/projectkorra/rpg/commands/HelpCommand.java
@@ -52,7 +52,11 @@ public class HelpCommand extends RPGCommand {
 			for (WorldEvent event : WorldEvent.getEvents()) {
 				if (args.get(0).equalsIgnoreCase(event.getName()) || event.getAliases().contains(args.get(0).toLowerCase())) {
 					sender.sendMessage(ChatColor.BOLD + event.getName());
-					sender.sendMessage(event.getElement().getColor() + event.getDescription());
+					sender.sendMessage(event.getTextColor() + event.getDescription());
+					sender.sendMessage(ChatColor.WHITE + "Affected Elements:");
+					for (Element e : event.getElements()) {
+						sender.sendMessage("- " + e.getColor() + e.getName());
+					}
 					return;
 				}
 			}

--- a/src/com/projectkorra/rpg/events/SunRiseEvent.java
+++ b/src/com/projectkorra/rpg/events/SunRiseEvent.java
@@ -1,16 +1,16 @@
-package com.projectkorra.rpg.worldevent.event;
+package com.projectkorra.rpg.events;
 
 import org.bukkit.World;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 
-public class SunSetEvent extends Event {
+public class SunRiseEvent extends Event {
 
 	private static final HandlerList handlers = new HandlerList();
 
 	private World world;
 
-	public SunSetEvent(World world) {
+	public SunRiseEvent(World world) {
 		this.world = world;
 	}
 

--- a/src/com/projectkorra/rpg/events/SunSetEvent.java
+++ b/src/com/projectkorra/rpg/events/SunSetEvent.java
@@ -1,16 +1,16 @@
-package com.projectkorra.rpg.worldevent.event;
+package com.projectkorra.rpg.events;
 
 import org.bukkit.World;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 
-public class SunRiseEvent extends Event {
+public class SunSetEvent extends Event {
 
 	private static final HandlerList handlers = new HandlerList();
 
 	private World world;
 
-	public SunRiseEvent(World world) {
+	public SunSetEvent(World world) {
 		this.world = world;
 	}
 

--- a/src/com/projectkorra/rpg/events/WorldEventEndEvent.java
+++ b/src/com/projectkorra/rpg/events/WorldEventEndEvent.java
@@ -1,4 +1,4 @@
-package com.projectkorra.rpg.worldevent.event;
+package com.projectkorra.rpg.events;
 
 import org.bukkit.World;
 import org.bukkit.event.Cancellable;

--- a/src/com/projectkorra/rpg/events/WorldEventStartEvent.java
+++ b/src/com/projectkorra/rpg/events/WorldEventStartEvent.java
@@ -1,4 +1,4 @@
-package com.projectkorra.rpg.worldevent.event;
+package com.projectkorra.rpg.events;
 
 import org.bukkit.World;
 import org.bukkit.event.Cancellable;

--- a/src/com/projectkorra/rpg/worldevent/IWorldEvent.java
+++ b/src/com/projectkorra/rpg/worldevent/IWorldEvent.java
@@ -34,6 +34,13 @@ public interface IWorldEvent {
 	 * @return list of attributes
 	 */
 	public List<String> getAttributes();
+	
+	/**
+	 * A list of worldevents which cannot concurrently occur with this worldevent
+	 * 
+	 * @return blacklisted events
+	 */
+	public List<String> getBlacklistedEvents();
 
 	/**
 	 * Which element the WorldEvent should affect. This will work with custom

--- a/src/com/projectkorra/rpg/worldevent/IWorldEvent.java
+++ b/src/com/projectkorra/rpg/worldevent/IWorldEvent.java
@@ -1,6 +1,10 @@
 package com.projectkorra.rpg.worldevent;
 
 import java.util.List;
+import java.util.Set;
+
+import org.bukkit.ChatColor;
+import org.bukkit.boss.BarColor;
 
 import com.projectkorra.projectkorra.Element;
 import com.projectkorra.rpg.worldevent.util.Time;
@@ -48,7 +52,7 @@ public interface IWorldEvent {
 	 * 
 	 * @return element the WorldEvent affects
 	 */
-	public Element getElement();
+	public Set<Element> getElements();
 
 	/**
 	 * Denotes when the WorldEvent should occur
@@ -106,4 +110,18 @@ public interface IWorldEvent {
 	 * @return true if the WorldEvent will create fog in the world
 	 */
 	public boolean getCreateFog();
+	
+	/**
+	 * Gets the color of chat text for the event
+	 * 
+	 * @return color of chat text
+	 */
+	public ChatColor getTextColor();
+	
+	/**
+	 * Gets the color of the bossbar for the event
+	 * 
+	 * @return color of the bossbar
+	 */
+	public BarColor getBarColor();
 }

--- a/src/com/projectkorra/rpg/worldevent/WorldEvent.java
+++ b/src/com/projectkorra/rpg/worldevent/WorldEvent.java
@@ -35,12 +35,13 @@ public class WorldEvent implements IWorldEvent {
 	private String endMessage;
 	private boolean darkenSky;
 	private boolean createFog;
+	private List<String> eventBlacklist;
 
 	public WorldEvent(WorldEventFile wFile) {
-		this(wFile.getName(), wFile.getDescription(), wFile.getAliases(), wFile.getAttributes(), Element.getElement(wFile.getElement()), Time.valueOf(wFile.getTime().toUpperCase()), wFile.getFrequency(), wFile.getModifier(), wFile.getStartMessage(), wFile.getEndMessage(), wFile.getDarkenSky(), wFile.getCreateFog());
+		this(wFile.getName(), wFile.getDescription(), wFile.getAliases(), wFile.getAttributes(), Element.getElement(wFile.getElement()), Time.valueOf(wFile.getTime().toUpperCase()), wFile.getFrequency(), wFile.getModifier(), wFile.getStartMessage(), wFile.getEndMessage(), wFile.getDarkenSky(), wFile.getCreateFog(), wFile.getEventBlacklist());
 	}
 
-	public WorldEvent(String name, String description, List<String> aliases, List<String> attributes, Element element, Time time, int frequency, double modifier, String startMessage, String endMessage, boolean darkenSky, boolean createFog) {
+	public WorldEvent(String name, String description, List<String> aliases, List<String> attributes, Element element, Time time, int frequency, double modifier, String startMessage, String endMessage, boolean darkenSky, boolean createFog, List<String> eventBlacklist) {
 		this.name = name;
 		this.description = description;
 		this.aliases = aliases;
@@ -53,6 +54,7 @@ public class WorldEvent implements IWorldEvent {
 		this.endMessage = endMessage;
 		this.darkenSky = darkenSky;
 		this.createFog = createFog;
+		this.eventBlacklist = eventBlacklist;
 		events.put(name.toLowerCase(), this);
 		if (!eventsByElement.containsKey(element)) {
 			eventsByElement.put(element, new HashSet<>());
@@ -78,6 +80,11 @@ public class WorldEvent implements IWorldEvent {
 	@Override
 	public List<String> getAttributes() {
 		return attributes;
+	}
+	
+	@Override
+	public List<String> getBlacklistedEvents() {
+		return eventBlacklist;
 	}
 
 	@Override

--- a/src/com/projectkorra/rpg/worldevent/WorldEvent.java
+++ b/src/com/projectkorra/rpg/worldevent/WorldEvent.java
@@ -1,11 +1,14 @@
 package com.projectkorra.rpg.worldevent;
 
-import java.util.Collection;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
+import org.bukkit.ChatColor;
+import org.bukkit.boss.BarColor;
 
 import com.projectkorra.projectkorra.Element;
 import com.projectkorra.rpg.ProjectKorraRPG;
@@ -15,19 +18,12 @@ import com.projectkorra.rpg.worldevent.util.WorldEventFile;
 public class WorldEvent implements IWorldEvent {
 
 	protected static Map<String, WorldEvent> events = new HashMap<>();
-	protected static Map<Element, Set<WorldEvent>> eventsByElement = new HashMap<>();
-
-	static {
-		for (Element e : Element.getAllElements()) {
-			eventsByElement.put(e, new HashSet<>());
-		}
-	}
 
 	private String name;
 	private String description;
 	private List<String> aliases;
 	private List<String> attributes;
-	private Element element;
+	private Set<Element> elements;
 	private Time time;
 	private int frequency;
 	private double modifier;
@@ -36,17 +32,19 @@ public class WorldEvent implements IWorldEvent {
 	private boolean darkenSky;
 	private boolean createFog;
 	private List<String> eventBlacklist;
+	private ChatColor text;
+	private BarColor bar;
 
 	public WorldEvent(WorldEventFile wFile) {
-		this(wFile.getName(), wFile.getDescription(), wFile.getAliases(), wFile.getAttributes(), Element.getElement(wFile.getElement()), Time.valueOf(wFile.getTime().toUpperCase()), wFile.getFrequency(), wFile.getModifier(), wFile.getStartMessage(), wFile.getEndMessage(), wFile.getDarkenSky(), wFile.getCreateFog(), wFile.getEventBlacklist());
+		this(wFile.getName(), wFile.getDescription(), wFile.getAliases(), wFile.getAttributes(), wFile.getElements(), wFile.getTime(), wFile.getFrequency(), wFile.getModifier(), wFile.getStartMessage(), wFile.getEndMessage(), wFile.getDarkenSky(), wFile.getCreateFog(), wFile.getEventBlacklist(), wFile.getTextColor(), wFile.getBarColor());
 	}
 
-	public WorldEvent(String name, String description, List<String> aliases, List<String> attributes, Element element, Time time, int frequency, double modifier, String startMessage, String endMessage, boolean darkenSky, boolean createFog, List<String> eventBlacklist) {
+	public WorldEvent(String name, String description, List<String> aliases, List<String> attributes, Element[] elements, Time time, int frequency, double modifier, String startMessage, String endMessage, boolean darkenSky, boolean createFog, List<String> eventBlacklist, ChatColor text, BarColor bar) {
 		this.name = name;
 		this.description = description;
 		this.aliases = aliases;
 		this.attributes = attributes;
-		this.element = element;
+		this.elements = new HashSet<>(Arrays.asList(elements));
 		this.time = time;
 		this.frequency = frequency;
 		this.modifier = modifier;
@@ -55,11 +53,9 @@ public class WorldEvent implements IWorldEvent {
 		this.darkenSky = darkenSky;
 		this.createFog = createFog;
 		this.eventBlacklist = eventBlacklist;
+		this.text = text;
+		this.bar = bar;
 		events.put(name.toLowerCase(), this);
-		if (!eventsByElement.containsKey(element)) {
-			eventsByElement.put(element, new HashSet<>());
-		}
-		eventsByElement.get(element).add(this);
 	}
 
 	@Override
@@ -88,8 +84,8 @@ public class WorldEvent implements IWorldEvent {
 	}
 
 	@Override
-	public Element getElement() {
-		return element;
+	public Set<Element> getElements() {
+		return elements;
 	}
 
 	@Override
@@ -126,23 +122,26 @@ public class WorldEvent implements IWorldEvent {
 	public boolean getCreateFog() {
 		return createFog;
 	}
+	
+	@Override
+	public ChatColor getTextColor() {
+		return text;
+	}
+	
+	@Override
+	public BarColor getBarColor() {
+		return bar;
+	}
 
 	public static WorldEvent get(String name) {
 		return events.containsKey(name.toLowerCase()) ? events.get(name.toLowerCase()) : (ProjectKorraRPG.getFileManager().loadFile(name.toLowerCase()) == null ? null : get(name));
 	}
 
-	public static Set<WorldEvent> getEventsByElement(Element e) {
-		if (!eventsByElement.containsKey(e)) {
-			eventsByElement.put(e, new HashSet<>());
-		}
-		return eventsByElement.get(e);
-	}
-
 	public static Set<String> getEventNames() {
-		return events.keySet();
+		return new HashSet<>(events.keySet());
 	}
 
-	public static Collection<WorldEvent> getEvents() {
-		return events.values();
+	public static Set<WorldEvent> getEvents() {
+		return new HashSet<>(events.values());
 	}
 }

--- a/src/com/projectkorra/rpg/worldevent/util/EventManager.java
+++ b/src/com/projectkorra/rpg/worldevent/util/EventManager.java
@@ -72,6 +72,21 @@ public class EventManager implements Runnable {
 		if (marker.get(world).contains(event)) {
 			return;
 		}
+		
+		List<WorldEvent> removal = new ArrayList<>();
+		for (WorldEvent we : marker.get(world)) {
+			if (we.getBlacklistedEvents().contains(event.getName())) {
+				return;
+			}
+			
+			if (event.getBlacklistedEvents().contains(we.getName())) {
+				removal.add(we);
+			}
+		}
+		
+		for (WorldEvent we : removal) {
+			endEvent(world, we, true);
+		}
 
 		if (!natural) {
 			double daysLeft = event.getFrequency() - (Math.ceil((world.getFullTime() / 24000)) % event.getFrequency());
@@ -101,7 +116,7 @@ public class EventManager implements Runnable {
 		}
 	}
 
-	public void endEvent(World world, WorldEvent event) {
+	public void endEvent(World world, WorldEvent event, boolean blacklisted) {
 		if (!marker.get(world).contains(event)) {
 			return;
 		}
@@ -110,7 +125,11 @@ public class EventManager implements Runnable {
 		ProjectKorraRPG.getDisplayManager().removeBossBar(world, event);
 
 		for (Player player : world.getPlayers()) {
-			player.sendMessage(event.getElement().getColor() + event.getEndMessage());
+			if (blacklisted) {
+				player.sendMessage(event.getElement().getColor() + event.getName() + " was overpowered by another event!");
+			} else {
+				player.sendMessage(event.getElement().getColor() + event.getEndMessage());
+			}
 		}
 	}
 

--- a/src/com/projectkorra/rpg/worldevent/util/EventManager.java
+++ b/src/com/projectkorra/rpg/worldevent/util/EventManager.java
@@ -12,9 +12,9 @@ import org.bukkit.entity.Player;
 import com.projectkorra.projectkorra.command.Commands;
 import com.projectkorra.projectkorra.configuration.ConfigManager;
 import com.projectkorra.rpg.ProjectKorraRPG;
+import com.projectkorra.rpg.events.SunRiseEvent;
+import com.projectkorra.rpg.events.SunSetEvent;
 import com.projectkorra.rpg.worldevent.WorldEvent;
-import com.projectkorra.rpg.worldevent.event.SunRiseEvent;
-import com.projectkorra.rpg.worldevent.event.SunSetEvent;
 
 public class EventManager implements Runnable {
 
@@ -67,6 +67,10 @@ public class EventManager implements Runnable {
 			}
 		}
 	}
+	
+	public void startEvent(World world, WorldEvent event) {
+		startEvent(world, event, true);
+	}
 
 	public void startEvent(World world, WorldEvent event, boolean natural) {
 		if (marker.get(world).contains(event)) {
@@ -111,9 +115,13 @@ public class EventManager implements Runnable {
 		BossBar bar = ProjectKorraRPG.getDisplayManager().createBossBar(world, event);
 
 		for (Player player : world.getPlayers()) {
-			player.sendMessage(event.getElement().getColor() + event.getStartMessage());
+			player.sendMessage(event.getTextColor() + event.getStartMessage());
 			bar.addPlayer(player);
 		}
+	}
+	
+	public void endEvent(World world, WorldEvent event) {
+		endEvent(world, event, false);
 	}
 
 	public void endEvent(World world, WorldEvent event, boolean blacklisted) {
@@ -126,25 +134,25 @@ public class EventManager implements Runnable {
 
 		for (Player player : world.getPlayers()) {
 			if (blacklisted) {
-				player.sendMessage(event.getElement().getColor() + event.getName() + " was overpowered by another event!");
+				player.sendMessage(event.getTextColor() + event.getName() + " was overpowered by another event!");
 			} else {
-				player.sendMessage(event.getElement().getColor() + event.getEndMessage());
+				player.sendMessage(event.getTextColor() + event.getEndMessage());
 			}
 		}
 	}
 
-	public boolean shouldSkip(World world, WorldEvent event) {
+	public boolean isSkipping(World world, WorldEvent event) {
 		return skipper.get(world).contains(event);
 	}
 
 	public boolean setSkipping(World world, WorldEvent event, boolean skip) {
 		if (skip) {
-			if (!shouldSkip(world, event)) {
+			if (!isSkipping(world, event)) {
 				skipper.get(world).add(event);
 				return true;
 			}
 		} else {
-			if (shouldSkip(world, event)) {
+			if (isSkipping(world, event)) {
 				skipper.get(world).remove(event);
 				return true;
 			}

--- a/src/com/projectkorra/rpg/worldevent/util/WorldEventDisplayManager.java
+++ b/src/com/projectkorra/rpg/worldevent/util/WorldEventDisplayManager.java
@@ -38,7 +38,7 @@ public class WorldEventDisplayManager {
 				size++;
 				flags.add(BarFlag.CREATE_FOG);
 			}
-			BossBar bar = plugin.getServer().createBossBar("§l" + event.getTextColor() + event.getName(), event.getBarColor(), BarStyle.SOLID, flags.toArray(new BarFlag[size]));
+			BossBar bar = plugin.getServer().createBossBar(ChatColor.BOLD + (event.getTextColor() + event.getName()), event.getBarColor(), BarStyle.SOLID, flags.toArray(new BarFlag[size]));
 			if (!active.containsKey(world)) {
 				active.put(world, new HashMap<>());
 			}

--- a/src/com/projectkorra/rpg/worldevent/util/WorldEventFile.java
+++ b/src/com/projectkorra/rpg/worldevent/util/WorldEventFile.java
@@ -84,7 +84,11 @@ public class WorldEventFile {
 	}
 
 	public String getEndMessage() {
-		return config.getString("endmessage");
+		return config.getString("end-message");
+	}
+	
+	public List<String> getEventBlacklist() {
+		return config.getStringList("event-blacklist");
 	}
 
 	public File getFile() {
@@ -104,7 +108,7 @@ public class WorldEventFile {
 	}
 
 	public String getStartMessage() {
-		return config.getString("startmessage");
+		return config.getString("start-message");
 	}
 
 	public String getTime() {
@@ -112,11 +116,11 @@ public class WorldEventFile {
 	}
 
 	public boolean getDarkenSky() {
-		return config.getBoolean("darkensky");
+		return config.getBoolean("darken-sky");
 	}
 
 	public boolean getCreateFog() {
-		return config.getBoolean("createfog");
+		return config.getBoolean("create-fog");
 	}
 
 	public void setWorldEvent(WorldEvent event) {

--- a/src/com/projectkorra/rpg/worldevent/util/WorldEventFile.java
+++ b/src/com/projectkorra/rpg/worldevent/util/WorldEventFile.java
@@ -4,9 +4,12 @@ import java.io.File;
 import java.io.IOException;
 import java.util.List;
 
+import org.bukkit.ChatColor;
+import org.bukkit.boss.BarColor;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
 
+import com.projectkorra.projectkorra.Element;
 import com.projectkorra.rpg.ProjectKorraRPG;
 import com.projectkorra.rpg.worldevent.WorldEvent;
 
@@ -79,8 +82,8 @@ public class WorldEventFile {
 		return config.getString("description");
 	}
 
-	public String getElement() {
-		return config.getString("element");
+	public Element[] getElements() {
+		return config.getStringList("elements").stream().map(Element::getElement).filter((a) -> a != null).toArray(Element[]::new);
 	}
 
 	public String getEndMessage() {
@@ -111,8 +114,14 @@ public class WorldEventFile {
 		return config.getString("start-message");
 	}
 
-	public String getTime() {
-		return config.getString("time");
+	public Time getTime() {
+		Time time = Time.valueOf(config.getString("time").toUpperCase());
+		
+		if (time == null) {
+			time = Time.BOTH;
+		}
+		
+		return time;
 	}
 
 	public boolean getDarkenSky() {
@@ -121,6 +130,26 @@ public class WorldEventFile {
 
 	public boolean getCreateFog() {
 		return config.getBoolean("create-fog");
+	}
+	
+	public ChatColor getTextColor() {
+		ChatColor text = ChatColor.valueOf(config.getString("text-color").toUpperCase());
+		
+		if (text == null) {
+			text = ChatColor.WHITE;
+		}
+		
+		return text;
+	}
+	
+	public BarColor getBarColor() {
+		BarColor bar = BarColor.valueOf(config.getString("bar-color").toUpperCase());
+		
+		if (bar == null) {
+			bar = BarColor.WHITE;
+		}
+		
+		return bar;
 	}
 
 	public void setWorldEvent(WorldEvent event) {

--- a/src/com/projectkorra/rpg/worldevent/util/WorldEventFileBuilder.java
+++ b/src/com/projectkorra/rpg/worldevent/util/WorldEventFileBuilder.java
@@ -1,8 +1,11 @@
 package com.projectkorra.rpg.worldevent.util;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
+import org.bukkit.ChatColor;
+import org.bukkit.boss.BarColor;
 import org.bukkit.configuration.file.FileConfiguration;
 
 import com.projectkorra.projectkorra.Element;
@@ -13,7 +16,7 @@ public class WorldEventFileBuilder {
 	private String description;
 	private List<String> aliases;
 	private List<String> attributes;
-	private String element;
+	private List<String> elements;
 	private int frequency;
 	private double modifier;
 	private String time;
@@ -22,6 +25,8 @@ public class WorldEventFileBuilder {
 	private boolean darkenSky;
 	private boolean createFog;
 	private List<String> eventBlacklist;
+	private String textColor;
+	private String barColor;
 
 	public WorldEventFileBuilder() {
 		this.name = "GenericName";
@@ -34,6 +39,9 @@ public class WorldEventFileBuilder {
 		this.startMessage = "GenericStartMessage";
 		this.endMessage = "GenericEndMessage";
 		this.eventBlacklist = new ArrayList<>();
+		this.elements = new ArrayList<>();
+		this.textColor = "WHITE";
+		this.barColor = "WHITE";
 	}
 
 	public WorldEventFileBuilder name(String name) {
@@ -100,8 +108,20 @@ public class WorldEventFileBuilder {
 		return this;
 	}
 
-	public WorldEventFileBuilder element(Element element) {
-		this.element = element.getName();
+	public WorldEventFileBuilder addElement(Element element) {
+		this.elements.add(element.getName());
+		return this;
+	}
+	
+	public WorldEventFileBuilder addElements(Element... elements) {
+		for (Element element : elements) {
+			this.elements.add(element.getName());
+		}
+		return this;
+	}
+	
+	public WorldEventFileBuilder setElements(List<Element> elements) {
+		this.elements = Arrays.asList(elements.stream().map(Element::getName).toArray(String[]::new));
 		return this;
 	}
 
@@ -139,6 +159,16 @@ public class WorldEventFileBuilder {
 		this.createFog = createFog;
 		return this;
 	}
+	
+	public WorldEventFileBuilder barColor(BarColor color) {
+		this.barColor = color.toString();
+		return this;
+	}
+	
+	public WorldEventFileBuilder textColor(ChatColor color) {
+		this.textColor = color.name();
+		return this;
+	}
 
 	public WorldEventFile build() {
 		WorldEventFile wFile = new WorldEventFile(name);
@@ -147,7 +177,7 @@ public class WorldEventFileBuilder {
 		config.addDefault("name", name);
 		config.addDefault("description", description);
 		config.addDefault("aliases", aliases);
-		config.addDefault("element", element);
+		config.addDefault("elements", elements);
 		config.addDefault("time", time);
 		config.addDefault("modifier", modifier);
 		config.addDefault("attributes", attributes);
@@ -157,6 +187,8 @@ public class WorldEventFileBuilder {
 		config.addDefault("darken-sky", darkenSky);
 		config.addDefault("create-fog", createFog);
 		config.addDefault("event-blacklist", eventBlacklist);
+		config.addDefault("text-color", textColor);
+		config.addDefault("bar-color", barColor);
 
 		wFile.save();
 		return wFile;

--- a/src/com/projectkorra/rpg/worldevent/util/WorldEventFileBuilder.java
+++ b/src/com/projectkorra/rpg/worldevent/util/WorldEventFileBuilder.java
@@ -21,6 +21,7 @@ public class WorldEventFileBuilder {
 	private String endMessage;
 	private boolean darkenSky;
 	private boolean createFog;
+	private List<String> eventBlacklist;
 
 	public WorldEventFileBuilder() {
 		this.name = "GenericName";
@@ -32,6 +33,7 @@ public class WorldEventFileBuilder {
 		this.time = "BOTH";
 		this.startMessage = "GenericStartMessage";
 		this.endMessage = "GenericEndMessage";
+		this.eventBlacklist = new ArrayList<>();
 	}
 
 	public WorldEventFileBuilder name(String name) {
@@ -78,6 +80,23 @@ public class WorldEventFileBuilder {
 
 	public WorldEventFileBuilder setAttributes(List<String> attributes) {
 		this.attributes = attributes;
+		return this;
+	}
+	
+	public WorldEventFileBuilder addBlacklistedEvent(String event) {
+		this.eventBlacklist.add(event);
+		return this;
+	}
+	
+	public WorldEventFileBuilder addBlacklistedEvents(String... events) {
+		for (String event : events) {
+			this.eventBlacklist.add(event);
+		}
+		return this;
+	}
+	
+	public WorldEventFileBuilder setBlacklistedEvents(List<String> events) {
+		this.eventBlacklist = events;
 		return this;
 	}
 
@@ -133,10 +152,11 @@ public class WorldEventFileBuilder {
 		config.addDefault("modifier", modifier);
 		config.addDefault("attributes", attributes);
 		config.addDefault("frequency", frequency);
-		config.addDefault("startmessage", startMessage);
-		config.addDefault("endmessage", endMessage);
-		config.addDefault("darkensky", darkenSky);
-		config.addDefault("createfog", createFog);
+		config.addDefault("start-message", startMessage);
+		config.addDefault("end-message", endMessage);
+		config.addDefault("darken-sky", darkenSky);
+		config.addDefault("create-fog", createFog);
+		config.addDefault("event-blacklist", eventBlacklist);
 
 		wFile.save();
 		return wFile;

--- a/src/com/projectkorra/rpg/worldevent/util/WorldEventFileManager.java
+++ b/src/com/projectkorra/rpg/worldevent/util/WorldEventFileManager.java
@@ -5,6 +5,9 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.bukkit.ChatColor;
+import org.bukkit.boss.BarColor;
+
 import com.projectkorra.projectkorra.Element;
 import com.projectkorra.projectkorra.attribute.Attribute;
 import com.projectkorra.rpg.ProjectKorraRPG;
@@ -33,7 +36,9 @@ public class WorldEventFileManager {
 		.name("FullMoon")
 		.setAliases(Arrays.asList("fm", "fullm", "fmoon", "moon"))
 		.setAttributes(Arrays.asList(Attribute.DAMAGE + mult, Attribute.HEIGHT + mult, Attribute.RANGE + mult, Attribute.WIDTH + mult, Attribute.KNOCKBACK + mult, Attribute.CHARGE_DURATION + divi, Attribute.COOLDOWN + divi, Attribute.SPEED + mult))
-		.element(Element.WATER)
+		.addElement(Element.WATER)
+		.barColor(BarColor.BLUE)
+		.textColor(ChatColor.DARK_AQUA)
 		.modifier(3.0)
 		.frequency(8)
 		.time(Time.NIGHT)
@@ -46,7 +51,9 @@ public class WorldEventFileManager {
 		.name("SozinsComet")
 		.setAliases(Arrays.asList("sc", "sozinsc", "scomet", "comet"))
 		.setAttributes(Arrays.asList(Attribute.DAMAGE + mult, Attribute.RANGE + mult, Attribute.KNOCKBACK + mult, Attribute.CHARGE_DURATION + divi, Attribute.DURATION + mult, Attribute.SPEED + mult, Attribute.WIDTH + mult))
-		.element(Element.FIRE)
+		.addElement(Element.FIRE)
+		.barColor(BarColor.RED)
+		.textColor(ChatColor.DARK_RED)
 		.modifier(5.0)
 		.frequency(100)
 		.time(Time.BOTH)
@@ -60,7 +67,9 @@ public class WorldEventFileManager {
 		new WorldEventFileBuilder()
 		.name("SolarEclipse")
 		.setAliases(Arrays.asList("se", "solare", "seclipse", "solar"))
-		.element(Element.FIRE)
+		.addElement(Element.FIRE)
+		.barColor(BarColor.RED)
+		.textColor(ChatColor.RED)
 		.modifier(0.0)
 		.frequency(14)
 		.time(Time.DAY)
@@ -72,7 +81,9 @@ public class WorldEventFileManager {
 		new WorldEventFileBuilder()
 		.name("LunarEclipse")
 		.setAliases(Arrays.asList("le", "lunare", "leclipse", "lunar"))
-		.element(Element.WATER)
+		.addElement(Element.WATER)
+		.barColor(BarColor.BLUE)
+		.textColor(ChatColor.AQUA)
 		.modifier(0.0)
 		.frequency(22)
 		.time(Time.NIGHT)
@@ -80,6 +91,37 @@ public class WorldEventFileManager {
 		.startMessage("A lunar eclipse is out! Waterbenders are temporarily powerless.")
 		.endMessage("The lunar eclipse has ended!")
 		.addBlacklistedEvent("FullMoon")
+		.build();
+		
+		new WorldEventFileBuilder()
+		.name("HarmonicConvergence")
+		.setAliases(Arrays.asList("hc", "harmonic", "convergence", "hconvergence"))
+		.setAttributes(Arrays.asList(Attribute.DAMAGE + mult, Attribute.CHARGE_DURATION + divi, Attribute.COOLDOWN + divi, Attribute.KNOCKBACK + mult, Attribute.DURATION + mult, Attribute.WIDTH + mult, Attribute.SPEED + mult, Attribute.HEIGHT + mult))
+		.addElements(Element.AIR, Element.EARTH, Element.FIRE, Element.WATER)
+		.barColor(BarColor.PINK)
+		.textColor(ChatColor.WHITE)
+		.modifier(3.0)
+		.frequency(10000)
+		.time(Time.BOTH)
+		.description("Harmonic Convergence is a supernatural phenomenon that occurs once every ten thousand years. When the planets align, spiritual energy is greatly amplified, causing the spirit portals at the North and South Poles to merge, while an aura of spirit energy envelops the Earth.")
+		.startMessage("Harmonic Convergence has flooded the world with spiritual energy, empowering all bending for the day!")
+		.endMessage("Harmonic Convergence has ended!")
+		.addBlacklistedEvents("SolarEclipse", "LunarEclipse")
+		.build();
+		
+		new WorldEventFileBuilder()
+		.name("BloodMoon")
+		.setAliases(Arrays.asList("bloodm", "bm", "bmoon"))
+		.addElements(Element.FIRE, Element.WATER)
+		.barColor(BarColor.RED)
+		.textColor(ChatColor.DARK_AQUA)
+		.modifier(0.0)
+		.frequency(64)
+		.time(Time.NIGHT)
+		.description("A bloodmoon occurs when someone disgraces the moon spirit, subsequently causing the moon to turn a blood-red and breaking firebenders and waterbenders spiritual connections!")
+		.startMessage("Someone disgraced the moon spirit and has caused the moon to turn blood-red and causing firebending and waterbending to subside. Firebenders and waterbenders are powerless!")
+		.endMessage("The moon spirit has been restored and the blood moon has gone away!")
+		.addBlacklistedEvents("SozinsComet", "LunarEclipse", "FullMoon")
 		.build();
 	}
 
@@ -125,10 +167,8 @@ public class WorldEventFileManager {
 			throw new WorldEventFileException(message.replaceAll("(f)", "Description"));
 		} else if (wFile.getAliases() == null || wFile.getAliases().isEmpty()) {
 			throw new WorldEventFileException(message.replaceAll("(f)", "Aliases"));
-		} else if (wFile.getElement() == null || wFile.getElement().isEmpty() || Element.getElement(wFile.getElement()) == null) {
-			throw new WorldEventFileException(message.replaceAll("(f)", "Element"));
-		} else if (wFile.getTime() == null || wFile.getTime().isEmpty() || Time.valueOf(wFile.getTime().toUpperCase()) == null) {
-			throw new WorldEventFileException(message.replaceAll("(f)", "Time"));
+		} else if (wFile.getElements().length == 0) {
+			throw new WorldEventFileException(message.replaceAll("(f)", "Elements"));
 		} else if (wFile.getEndMessage() == null || wFile.getEndMessage().isEmpty()) {
 			throw new WorldEventFileException(message.replaceAll("(f)", "End Message"));
 		} else if (wFile.getStartMessage() == null || wFile.getStartMessage().isEmpty()) {

--- a/src/com/projectkorra/rpg/worldevent/util/WorldEventFileManager.java
+++ b/src/com/projectkorra/rpg/worldevent/util/WorldEventFileManager.java
@@ -29,13 +29,58 @@ public class WorldEventFileManager {
 	}
 
 	private void createDefaults() {
-		new WorldEventFileBuilder().name("FullMoon").setAliases(Arrays.asList("fm", "fullm", "fmoon", "moon")).setAttributes(Arrays.asList(Attribute.DAMAGE + mult, Attribute.HEIGHT + mult, Attribute.RANGE + mult, Attribute.WIDTH + mult, Attribute.KNOCKBACK + mult, Attribute.CHARGE_DURATION + divi, Attribute.COOLDOWN + divi, Attribute.SPEED + mult)).element(Element.WATER).modifier(3.0).frequency(8).time(Time.NIGHT).description("When the full moon rises overhead waterbending is greatly enhanced due to its lunar affinity. This is almost always to the point where a single waterbender can overpower multiple opponents with relative ease.").startMessage("A full moon is rising, empowering waterbending like never before.").endMessage("The full moon has passed, waterbending is no longer empowered!").build();
+		new WorldEventFileBuilder()
+		.name("FullMoon")
+		.setAliases(Arrays.asList("fm", "fullm", "fmoon", "moon"))
+		.setAttributes(Arrays.asList(Attribute.DAMAGE + mult, Attribute.HEIGHT + mult, Attribute.RANGE + mult, Attribute.WIDTH + mult, Attribute.KNOCKBACK + mult, Attribute.CHARGE_DURATION + divi, Attribute.COOLDOWN + divi, Attribute.SPEED + mult))
+		.element(Element.WATER)
+		.modifier(3.0)
+		.frequency(8)
+		.time(Time.NIGHT)
+		.description("When the full moon rises overhead waterbending is greatly enhanced due to its lunar affinity. This is almost always to the point where a single waterbender can overpower multiple opponents with relative ease.")
+		.startMessage("A full moon is rising, empowering waterbending like never before.")
+		.endMessage("The full moon has passed, waterbending is no longer empowered!")
+		.build();
 
-		new WorldEventFileBuilder().name("SozinsComet").setAliases(Arrays.asList("sc", "sozinsc", "scomet", "comet")).setAttributes(Arrays.asList(Attribute.DAMAGE + mult, Attribute.RANGE + mult, Attribute.KNOCKBACK + mult, Attribute.CHARGE_DURATION + divi, Attribute.DURATION + mult, Attribute.SPEED + mult, Attribute.WIDTH + mult)).element(Element.FIRE).modifier(5.0).frequency(100).time(Time.BOTH).description("As Sozin's Comet streaks through the upper atmosphere, firebending is drastically enhanced. With an extraterrestrial heat source so much closer to the planet than the Sun, all firebenders become capable of massive destruction.").startMessage("Sozin's Comet is passing overhead! Firebending is now at its most powerful.").endMessage("Sozin's comet has passed, firebending is no longer empowered!").darkenSky(true).build();
+		new WorldEventFileBuilder()
+		.name("SozinsComet")
+		.setAliases(Arrays.asList("sc", "sozinsc", "scomet", "comet"))
+		.setAttributes(Arrays.asList(Attribute.DAMAGE + mult, Attribute.RANGE + mult, Attribute.KNOCKBACK + mult, Attribute.CHARGE_DURATION + divi, Attribute.DURATION + mult, Attribute.SPEED + mult, Attribute.WIDTH + mult))
+		.element(Element.FIRE)
+		.modifier(5.0)
+		.frequency(100)
+		.time(Time.BOTH)
+		.description("As Sozin's Comet streaks through the upper atmosphere, firebending is drastically enhanced. With an extraterrestrial heat source so much closer to the planet than the Sun, all firebenders become capable of massive destruction.")
+		.startMessage("Sozin's Comet is passing overhead! Firebending is now at its most powerful.")
+		.endMessage("Sozin's comet has passed, firebending is no longer empowered!")
+		.darkenSky(true)
+		.addBlacklistedEvent("SolarEclipse")
+		.build();
 
-		new WorldEventFileBuilder().name("SolarEclipse").setAliases(Arrays.asList("se", "solare", "seclipse", "solar")).element(Element.FIRE).modifier(0.0).frequency(14).time(Time.DAY).description("As the sky darkens during a solar eclipse, all firebending subsides. Firebenders typically draw their power from the sun and are unable to do so while their connection is temporarily severed.").startMessage("A solar eclipse is out! Firebenders are temporarily powerless.").endMessage("The solar eclipse has ended!").build();
+		new WorldEventFileBuilder()
+		.name("SolarEclipse")
+		.setAliases(Arrays.asList("se", "solare", "seclipse", "solar"))
+		.element(Element.FIRE)
+		.modifier(0.0)
+		.frequency(14)
+		.time(Time.DAY)
+		.description("As the sky darkens during a solar eclipse, all firebending subsides. Firebenders typically draw their power from the sun and are unable to do so while their connection is temporarily severed.")
+		.startMessage("A solar eclipse is out! Firebenders are temporarily powerless.")
+		.endMessage("The solar eclipse has ended!")
+		.build();
 
-		new WorldEventFileBuilder().name("LunarEclipse").setAliases(Arrays.asList("le", "lunare", "leclipse", "lunar")).element(Element.WATER).modifier(0.0).frequency(22).time(Time.NIGHT).description("As the moon darkens during a lunar eclipse, all waterbending subsides. Waterbenders typically draw their power from the moon and are unable to do so while their connection is temporarily severed.").startMessage("A lunar eclipse is out! Waterbenders are temporarily powerless.").endMessage("The lunar eclipse has ended!").build();
+		new WorldEventFileBuilder()
+		.name("LunarEclipse")
+		.setAliases(Arrays.asList("le", "lunare", "leclipse", "lunar"))
+		.element(Element.WATER)
+		.modifier(0.0)
+		.frequency(22)
+		.time(Time.NIGHT)
+		.description("As the moon darkens during a lunar eclipse, all waterbending subsides. Waterbenders typically draw their power from the moon and are unable to do so while their connection is temporarily severed.")
+		.startMessage("A lunar eclipse is out! Waterbenders are temporarily powerless.")
+		.endMessage("The lunar eclipse has ended!")
+		.addBlacklistedEvent("FullMoon")
+		.build();
 	}
 
 	public void loadFiles() {
@@ -92,9 +137,9 @@ public class WorldEventFileManager {
 			throw new WorldEventFileException(message.replaceAll("(f)", "Frequency"));
 		} else if (Double.valueOf(wFile.getModifier()) == null) {
 			throw new WorldEventFileException(message.replaceAll("(f)", "Modifier"));
-		} else if (!wFile.getConfig().contains("darkensky")) {
+		} else if (!wFile.getConfig().contains("darken-sky")) {
 			wFile.getConfig().addDefault("darkensky", false);
-		} else if (!wFile.getConfig().contains("createfog")) {
+		} else if (!wFile.getConfig().contains("create-fog")) {
 			wFile.getConfig().addDefault("createfog", false);
 		}
 	}


### PR DESCRIPTION
## Additions
* Added an option in worldevent files to specify other events which cannot occur at the same time as the configured event. E.g. if SolarEclipse is listed in the SozinsComet blacklist, then whenever they would happen concurrently SozinsComet instead overpowers / cancels SolarEclipse.

## Misc. Changes
* Changed options which are two words to be separated by `-` rather than just combined together for easier readability.